### PR TITLE
Updated mirror diameter.

### DIFF
--- a/data/Observatory/MissionandObservatoryTechnicalOverview/MissionandObservatory.yaml
+++ b/data/Observatory/MissionandObservatoryTechnicalOverview/MissionandObservatory.yaml
@@ -12,7 +12,7 @@ Mission_and_Spacecraft_Parameters:
   refuel: able to be robotically refueled in-flight
 
 Telescope_Parameters:
-  primary_mirror_diameter: 2.4 meters
+  primary_mirror_diameter: 2.36 meters (diameter of the aperture stop)
   mirror_temperature: 265 K
   allowed_roll_angle_range: -15 to +15 degrees around angle providing max solar panel
   jitter: 12 milliarcseconds

--- a/data/Observatory/MissionandObservatoryTechnicalOverview/MissionandObservatory.yaml
+++ b/data/Observatory/MissionandObservatoryTechnicalOverview/MissionandObservatory.yaml
@@ -12,7 +12,8 @@ Mission_and_Spacecraft_Parameters:
   refuel: able to be robotically refueled in-flight
 
 Telescope_Parameters:
-  primary_mirror_diameter: 2.36 meters (diameter of the aperture stop)
+  primary_mirror_diameter: 2.4 meters
+  primary_mirror_effective_diameter: 2.36 meters (diameter of the aperture stop)
   mirror_temperature: 265 K
   allowed_roll_angle_range: -15 to +15 degrees around angle providing max solar panel
   jitter: 12 milliarcseconds

--- a/data/WideFieldInstrument/Spectroscopy/Sensitivity/prism_spectroscopy_sensitivity.ecsv
+++ b/data/WideFieldInstrument/Spectroscopy/Sensitivity/prism_spectroscopy_sensitivity.ecsv
@@ -3,14 +3,14 @@
 # datatype:
 # - {name: wavelength, unit: um, datatype: float64, description: wavelength in microns}
 # - {name: delta_lambda, unit: nm, datatype: float64, description: delta wavelength for 1 pixel in nanometers}
-# - {name: mAB_point_one_hr, unit: ABmag, datatype: float64, description: 5-sigma detection limit for a 1-hour exposure time with zodiacal light background at twice the minimum intensity for a (1-pixel) point source in units of AB magnitude at which S/N=5 per pixel.}
-# - {name: mAB_galaxy_one_hr, unit: ABmag, datatype: float64, description: 5-sigma detection limit for a 1-hour exposure time with zodiacal light background at twice the minimum intensity for a point source's continua in units of AB magnitude at which S/N=5 per pixel.}
-# - {name: mAB_point_sixty_two_sec, unit: ABmag, datatype: float64, description: 5-sigma detection limit for a 1-hour exposure time with zodiacal light background at twice the minimum intensity for a compact galaxy's (with half-light radius of 0.3 arcseconds) emission line's integrated flux in units of 1E-17 ergs/cm^2/sec.}
-# - {name: mAB_galaxy_sixty_two_sec, unit: ABmag, datatype: float64, description: 5-sigma detection limit for a 1-hour exposure time with zodiacal light background at twice the minimum intensity for a compact galaxy's (with half-light radius of 0.3 arcseconds) continua in units of AB magnitude at which S/N=5 per pixel.}
+# - {name: mAB_point_one_hr, unit: ABmag, datatype: float64, description: 5-sigma (per pixel) detection limit for a 1-hour exposure time with zodiacal light background at twice the minimum intensity for a point source in units of AB magnitude (mAB) at which S/N=5 per pixel.}
+# - {name: mAB_galaxy_one_hr, unit: ABmag, datatype: float64, description: 5-sigma (per pixel) detection limit for a 1-hour exposure time with zodiacal light background at twice the minimum intensity for a compact galaxy (an exponential disk with half-light radius=0.3") in units of AB magnitude (mAB) at which S/N=5 per pixel.}
+# - {name: mAB_point_sixty_two_sec, unit: ABmag, datatype: float64, description: 5-sigma (per pixel) detection limit for a 62-second exposure time with zodiacal light background at twice the minimum intensity for a point source in units of AB magnitude (mAB) at which S/N=5 per pixel.}
+# - {name: mAB_galaxy_sixty_two_sec, unit: ABmag, datatype: float64, description: 5-sigma (per pixel) detection limit for a 62-second exposure time with zodiacal light background at twice the minimum intensity for a compact galaxy (an exponential disk with half-light radius=0.3") in units of AB magnitude (mAB) at which S/N=5 per pixel.}
 # delimiter: ','
 # meta: !!omap
 # - {comments: Roman/WFI prism (P127) spectroscopy sensitivity.}
-# - {last updated: '2024-June-11'}
+# - {last updated: '2024-Nov-08'}
 # schema: astropy-2.0
 
 wavelength,     delta_lambda,       mAB_point_one_hr,       mAB_galaxy_one_hr,      mAB_point_sixty_two_sec,        mAB_galaxy_sixty_two_sec


### PR DESCRIPTION
Addresses issue #14 - 2.36-m is the "effective" mirror diameter (according to Jeff Kruk) as it is the diameter of the aperture stop. The mirror itself is larger.